### PR TITLE
Switched activation to Admins (instead of devMode)

### DIFF
--- a/cpfieldlinks/CpFieldLinksPlugin.php
+++ b/cpfieldlinks/CpFieldLinksPlugin.php
@@ -64,8 +64,9 @@ class CpFieldLinksPlugin extends BasePlugin
         parent::init();
 
         $request = craft()->request;
+        $currentUser = craft()->userSession->getUser();
 
-        if (!$request->isCpRequest() || $request->isAjaxRequest() || craft()->isConsole() || !$this->isCraftRequiredVersion() || !craft()->config->get('devMode')) {
+        if (!$currentUser || !$currentUser->admin || !$request->isCpRequest() || $request->isAjaxRequest() || craft()->isConsole() || !$this->isCraftRequiredVersion()) {
             return false;
         }
 


### PR DESCRIPTION
Closes #2 

This PR switches the activation mechanism. Instead of being reliant on `devMode`, it now relies on the user being **logged in as an admin**. This allows admins to use it on production sites.
